### PR TITLE
Add Colormap Generation to Geometry Nodes Editor

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,14 +59,6 @@ def make_enum_item(_id, name, descr, preview_id, uid):
     return _item_map[lookup]
 
 
-def property_exists(prop_path, glob, loc):
-    try:
-        eval(prop_path, glob, loc)
-        return True
-    except:
-        return False
-
-
 def sna_colormaps_E002E():
     cmaps = None
     import cmocean

--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ from bpy.app.handlers import persistent
 good = True
 
 try:
-    import matplotlib.pyplot as plt
+    import matplotlib
     import cmocean
     import colorcet
 
@@ -61,7 +61,7 @@ def sna_update_sna_color_libraries_22719(self, context):
     sna_updated_prop = self.sna_color_libraries
     library = sna_updated_prop
     cmaps = None
-    cmaps = sorted(plt.colormaps(), key = lambda x: x.lower())
+    cmaps = sorted(matplotlib.colormaps(), key = lambda x: x.lower())
     options = ['matplotlib','colorcet','cmocean']
     cmos = [i for i in cmaps if 'cmo.' in i]
     cets = [i for i in cmaps if 'cet_' in i and not i.endswith('_r')]
@@ -86,7 +86,6 @@ class SNA_OT_Install_Dependencies_E7270(bpy.types.Operator):
         return not False
 
     def execute(self, context):
-        import subprocess
         pyth_path = sys.executable
         for lib in ["matplotlib", "cmocean", "colorcet"]:
             subprocess.call([pyth_path, "-m","pip","install",lib])
@@ -101,23 +100,19 @@ class SNA_AddonPreferences_58A3E(bpy.types.AddonPreferences):
     bl_idname = 'blender_colormaps'
 
     def draw(self, context):
-        if not (False):
-            layout = self.layout 
-            if dependencies['sna_deps_installed']:
-                pass
-            else:
-                col_720D4 = layout.column(heading='', align=False)
-                col_720D4.alert = False
-                col_720D4.enabled = True
-                col_720D4.active = True
-                col_720D4.use_property_split = False
-                col_720D4.use_property_decorate = False
-                col_720D4.scale_x = 1.0
-                col_720D4.scale_y = 1.0
-                col_720D4.alignment = 'Expand'.upper()
-                if not True: col_720D4.operator_context = "EXEC_DEFAULT"
-                col_720D4.label(text='DEPENDENCIES MISSING', icon_value=778)
-                op = col_720D4.operator('sna.install_dependencies_e7270', text='Install Dependencies', icon_value=0, emboss=True, depress=False)
+        layout = self.layout
+        if not dependencies['sna_deps_installed']:
+            col_720D4 = layout.column(heading='', align=False)
+            col_720D4.alert = False
+            col_720D4.enabled = True
+            col_720D4.active = True
+            col_720D4.use_property_split = False
+            col_720D4.use_property_decorate = False
+            col_720D4.scale_x = 1.0
+            col_720D4.scale_y = 1.0
+            col_720D4.alignment = 'Expand'.upper()
+            col_720D4.label(text='DEPENDENCIES MISSING', icon_value=778)
+            col_720D4.operator('sna.install_dependencies_e7270', text='Install Dependencies', icon_value=0, emboss=True, depress=False)
 
 
 def sna_create_colorramp_0B482():
@@ -134,7 +129,7 @@ def sna_create_colorramp_0B482():
             nodes = modifier.node_group.nodes
             cramp = nodes.new(type='ShaderNodeValToRGB')
 
-    cmap = plt.get_cmap(cmap_name)
+    cmap = matplotlib.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     dis = 1/(steps-1)
     x   = dis
@@ -153,7 +148,7 @@ def sna_update_color_map_5D6A6():
     cmap_name = bpy.context.scene.sna_cmaps
 
     cramp = bpy.context.active_node
-    cmap = plt.get_cmap(cmap_name)
+    cmap = matplotlib.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     count=0
     for idx in range(len(el.values())-1):

--- a/__init__.py
+++ b/__init__.py
@@ -298,9 +298,8 @@ class SNA_PT_COLORMAPS_321D4(bpy.types.Panel):
         split_20DBF.label(text='Steps', icon_value=0)
         split_20DBF.prop(bpy.context.scene, 'sna_colormap_steps', text='', icon_value=0, emboss=True)
         col_F7EAC.operator('sna.create_color_ramp_0dbb6', text='Create Color Ramp', icon_value=0, emboss=True, depress=False)
-        if bpy.context.active_node is not None:
-            if bpy.context.active_node.type == 'VALTORGB' and bpy.context.active_node.select:
-                col_F7EAC.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
+        if bpy.context.active_node is not None and (bpy.context.active_node.type == 'VALTORGB' and bpy.context.active_node.select):
+            col_F7EAC.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
 
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -178,6 +178,7 @@ class SNA_PT_COLORMAPS_C3E26(bpy.types.Panel):
         return modifier is not None and (
             modifier.type == 'NODES'
             and bpy.context.area.ui_type == 'GeometryNodeTree'
+            and modifier.node_group is not None
         )
 
     def draw_header(self, context):

--- a/__init__.py
+++ b/__init__.py
@@ -172,14 +172,13 @@ class SNA_PT_COLORMAPS_C3E26(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         mat = context.object.active_material
-        if mat is not None:
-            if mat.use_nodes and bpy.context.area.ui_type == 'ShaderNodeTree':
-                return True
+        if mat is not None and (mat.use_nodes and bpy.context.area.ui_type == 'ShaderNodeTree'):
+            return True
         modifier = context.object.modifiers.active
-        if modifier is not None:
-            if modifier.type == 'NODES' and bpy.context.area.ui_type == 'GeometryNodeTree':
-                return True
-        return False
+        return modifier is not None and (
+            modifier.type == 'NODES'
+            and bpy.context.area.ui_type == 'GeometryNodeTree'
+        )
 
     def draw_header(self, context):
         layout = self.layout
@@ -218,9 +217,8 @@ class SNA_PT_COLORMAPS_C3E26(bpy.types.Panel):
         split_20DBF.label(text='Steps', icon_value=0)
         split_20DBF.prop(bpy.context.scene, 'sna_colormap_steps', text='', icon_value=0, emboss=True)
         col_E8864.operator('sna.create_color_ramp_0dbb6', text='Create Color Ramp', icon_value=0, emboss=True, depress=False)
-        if bpy.context.active_node is not None:
-            if bpy.context.active_node.type == 'VALTORGB' and bpy.context.active_node.select:
-                col_E8864.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
+        if bpy.context.active_node is not None and (bpy.context.active_node.type == 'VALTORGB' and bpy.context.active_node.select):
+            col_E8864.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
 
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ from bpy.app.handlers import persistent
 good = True
 
 try:
-    import matplotlib
+    import matplotlib.pyplot as plt
     import cmocean
     import colorcet
 
@@ -61,7 +61,7 @@ def sna_update_sna_color_libraries_22719(self, context):
     sna_updated_prop = self.sna_color_libraries
     library = sna_updated_prop
     cmaps = None
-    cmaps = sorted(matplotlib.colormaps(), key = lambda x: x.lower())
+    cmaps = sorted(plt.colormaps(), key = lambda x: x.lower())
     options = ['matplotlib','colorcet','cmocean']
     cmos = [i for i in cmaps if 'cmo.' in i]
     cets = [i for i in cmaps if 'cet_' in i and not i.endswith('_r')]
@@ -122,9 +122,8 @@ class SNA_AddonPreferences_58A3E(bpy.types.AddonPreferences):
 
 def sna_create_colorramp_0B482():
     steps = bpy.data.scenes['Scene'].sna_colormap_steps
-    cmap_name = bpy.context.scene.sna_cmaps
-    import sys
-    import numpy as np
+    cmap_name = bpy.data.scenes['Scene'].sna_cmaps
+
     material = bpy.context.active_object.active_material
     modifier = bpy.context.object.modifiers.active
     if material is not None and bpy.context.area.ui_type == 'ShaderNodeTree':
@@ -134,7 +133,8 @@ def sna_create_colorramp_0B482():
         if modifier.type == 'NODES':
             nodes = modifier.node_group.nodes
             cramp = nodes.new(type='ShaderNodeValToRGB')
-    cmap = matplotlib.cm.get_cmap(cmap_name)
+
+    cmap = plt.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     dis = 1/(steps-1)
     x   = dis
@@ -151,11 +151,9 @@ def sna_create_colorramp_0B482():
 def sna_update_color_map_5D6A6():
     steps = bpy.data.scenes['Scene'].sna_colormap_steps
     cmap_name = bpy.context.scene.sna_cmaps
-    node_name = bpy.context.active_node.name
-    import matplotlib
-    import numpy as np
-    cmap = matplotlib.cm.get_cmap(cmap_name)
+
     cramp = bpy.context.active_node
+    cmap = plt.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     count=0
     for idx in range(len(el.values())-1):
@@ -170,7 +168,6 @@ def sna_update_color_map_5D6A6():
         pos = e.position
         e.color = [i**2.2 for i in cmap(pos)]
     cramp.label = cmap_name
-    return
 
 
 class SNA_OT_Update_Colorramp_8Fdfb(bpy.types.Operator):
@@ -300,9 +297,10 @@ class SNA_PT_COLORMAPS_321D4(bpy.types.Panel):
         split_20DBF.alignment = 'Expand'.upper()
         split_20DBF.label(text='Steps', icon_value=0)
         split_20DBF.prop(bpy.context.scene, 'sna_colormap_steps', text='', icon_value=0, emboss=True)
-        op = col_F7EAC.operator('sna.create_color_ramp_0dbb6', text='Create Color Ramp', icon_value=0, emboss=True, depress=False)
-        if bpy.context.active_node is not None and ((bpy.context.active_node.type == 'VALTORGB') and bpy.context.active_node.select):
-            op = col_F7EAC.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
+        col_F7EAC.operator('sna.create_color_ramp_0dbb6', text='Create Color Ramp', icon_value=0, emboss=True, depress=False)
+        if bpy.context.active_node is not None:
+            if bpy.context.active_node.type == 'VALTORGB' and bpy.context.active_node.select:
+                col_F7EAC.operator('sna.update_colorramp_8fdfb', text='Update Selected', icon_value=0, emboss=True, depress=False)
 
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -129,7 +129,7 @@ def sna_create_colorramp_0B482():
             nodes = modifier.node_group.nodes
             cramp = nodes.new(type='ShaderNodeValToRGB')
 
-    cmap = matplotlib.get_cmap(cmap_name)
+    cmap = matplotlib.cm.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     dis = 1/(steps-1)
     x   = dis
@@ -148,7 +148,7 @@ def sna_update_color_map_5D6A6():
     cmap_name = bpy.context.scene.sna_cmaps
 
     cramp = bpy.context.active_node
-    cmap = matplotlib.get_cmap(cmap_name)
+    cmap = matplotlib.cm.get_cmap(cmap_name)
     el = cramp.color_ramp.elements
     count=0
     for idx in range(len(el.values())-1):


### PR DESCRIPTION
Hello, this PR enables the generation of a color map in the Geometry Nodes Editor.
I needed to use the colormap node in the geometry nodes editor so I think it's more convenient to add this feature even though it is possible to generate the colormap node in the Shading Nodes editor and copy paste it in the Geometry Nodes editor.

I also refactored a bit the part of the code that I modified and removed the use of the function `property_exists`.